### PR TITLE
Feat: Add enum validation for confidence_level

### DIFF
--- a/src/api_handler.cpp
+++ b/src/api_handler.cpp
@@ -54,6 +54,25 @@ JsonValue process_api_request(const std::string& endpoint, const JsonValue& requ
         }
     }
     
+    // Validate 'confidence_level' for 'getMentalHealthGenes' endpoint
+    if (endpoint == "getMentalHealthGenes") {
+        if (request.object_value.count("parameters")) {
+            const auto& parameters = request.object_value.at("parameters").object_value;
+            if (parameters.count("confidence_level")) {
+                const auto& confidence_param = parameters.at("confidence_level");
+                if (confidence_param.type == JsonValue::STRING) {
+                    const std::string& value = confidence_param.string_value;
+                    const std::set<std::string> valid_levels = {"high", "medium", "low", "all"};
+                    if (valid_levels.find(value) == valid_levels.end()) {
+                        return create_error_response(
+                            "Invalid parameter: 'confidence_level' must be one of [high, medium, low, all]."
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     // If validation passes, return success
     return create_success_response("Request processed successfully for endpoint: " + endpoint);
 }

--- a/src/examples/flexible_json_usage_example.cpp
+++ b/src/examples/flexible_json_usage_example.cpp
@@ -138,7 +138,7 @@ int main() {
     JsonValue quick_input = JsonValue::makeObject();
     JsonValue quick_genes = JsonValue::makeArray();
     quick_genes.array_value.push_back(JsonValue::makeString("HTR2A"));
-    quick_input.object_value["genes"] = quick_genes;
+    quick_input.object_value["gene_ids"] = quick_genes;
     
     std::cout << "Quick lookup input: " << quick_input.serialize() << std::endl;
     std::cout << "Executing quick gene lookup workflow..." << std::endl;

--- a/src/unit_tests.cpp
+++ b/src/unit_tests.cpp
@@ -245,3 +245,29 @@ TEST_CASE(ApiHandler, AcceptsRequestWithValidArrayParameter) {
     ASSERT_EQUAL(response.object_value["success"].bool_value, true);
     ASSERT_TRUE(response.object_value["message"].string_value.find("Request processed successfully") != std::string::npos);
 }
+
+TEST_CASE(ApiHandler, RejectsGetMentalHealthGenesWithInvalidConfidence) {
+    JsonValue request = JsonValue::makeObject();
+    JsonValue params = JsonValue::makeObject();
+    params.object_value["confidence_level"] = JsonValue::makeString("invalid_value");
+    request.object_value["parameters"] = params;
+
+    JsonValue response = process_api_request("getMentalHealthGenes", request);
+
+    ASSERT_EQUAL(response.object_value["success"].bool_value, false);
+    ASSERT_TRUE(response.object_value.count("error") > 0);
+    std::string expected_msg = "Invalid parameter: 'confidence_level' must be one of [high, medium, low, all].";
+    ASSERT_EQUAL(response.object_value["error"].object_value["message"].string_value, expected_msg);
+}
+
+TEST_CASE(ApiHandler, AcceptsGetMentalHealthGenesWithValidConfidence) {
+    JsonValue request = JsonValue::makeObject();
+    JsonValue params = JsonValue::makeObject();
+    params.object_value["confidence_level"] = JsonValue::makeString("high");
+    request.object_value["parameters"] = params;
+
+    JsonValue response = process_api_request("getMentalHealthGenes", request);
+
+    ASSERT_EQUAL(response.object_value["success"].bool_value, true);
+    ASSERT_TRUE(response.object_value["message"].string_value.find("Request processed successfully") != std::string::npos);
+}


### PR DESCRIPTION
This commit implements server-side validation for enum-like parameters, as outlined in `docs/plan.md`.

- Adds logic to `api_handler.cpp` to validate the `confidence_level` parameter for the `getMentalHealthGenes` endpoint. It now only accepts "high", "medium", "low", or "all".
- Adds new unit tests to `unit_tests.cpp` to verify both the failure case (invalid value) and the success case (valid value) for the new validation logic.